### PR TITLE
Add network range summary and per-mask IP count to the subnet calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Rien de révolutionnaire, en sorte.
 | Nom de l'outil                                  | Description                                                                          | Lien                                                      |
 | ----------------------------------------------- | ------------------------------------------------------------------------------------ | --------------------------------------------------------- |
 | **Générateur de message d'absence**             | Crée une réponse automatique multilingue avec date dynamique et contact personnalisé | [`auto-reply-generator`](tools/auto-reply-generator.html) |
+| **Calculateur de sous-réseaux**                 | Décompose un réseau CIDR en sous-réseaux, affiche l'adresse de début, de fin et le nombre total d'IPs du réseau ainsi que le nombre d'IPs pour chaque taille de masque. Inventaire persistant des sous-réseaux utilisés. | [`subnets-calculator`](tools/subnets_calculator.html) |
 | _(À venir)_ Analyseur d'e-mails suspects        | Détection de phishing ou d'usurpation dans des en-têtes email                        |                                                           |
 | _(À venir)_ Convertisseur de date ISO/locale    | Affiche une date dans plusieurs formats et fuseaux                                   |                                                           |
 

--- a/tools/subnets_calculator.html
+++ b/tools/subnets_calculator.html
@@ -148,6 +148,24 @@
         margin-bottom: 15px;
         font-weight: bold;
       }
+      .network-summary {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 20px;
+        padding: 12px 16px;
+        background: #eaf4fb;
+        border: 1px solid #aed6f1;
+        border-radius: 6px;
+        margin-bottom: 20px;
+        font-family: monospace;
+      }
+      .summary-item {
+        font-size: 0.95em;
+        color: #1a5276;
+      }
+      .summary-item strong {
+        color: #333;
+      }
     </style>
   </head>
   <body>
@@ -174,6 +192,7 @@
       </div>
 
       <div id="errorLog" class="error"></div>
+      <div id="networkInfo"></div>
       <div id="results"></div>
     </div>
 
@@ -338,6 +357,7 @@
         const parts = input.split("/");
         if (parts.length !== 2) {
           errorDiv.textContent = "Format invalide.";
+          document.getElementById("networkInfo").innerHTML = "";
           return;
         }
 
@@ -348,6 +368,17 @@
         const baseInt = ipToInt(parts[0]);
         const networkStart = (baseInt & (0xffffffff << (32 - baseMask))) >>> 0;
         const totalIPs = Math.pow(2, 32 - baseMask);
+        const networkEnd = networkStart + totalIPs - 1;
+
+        const fmt = (n) => n.toLocaleString("fr-FR");
+        document.getElementById("networkInfo").innerHTML = `
+          <div class="network-summary">
+            <span class="summary-item"><strong>Réseau :</strong> ${intToIp(networkStart)}/${baseMask}</span>
+            <span class="summary-item"><strong>Première adresse :</strong> ${intToIp(networkStart)}</span>
+            <span class="summary-item"><strong>Dernière adresse :</strong> ${intToIp(networkEnd)}</span>
+            <span class="summary-item"><strong>Total IPs :</strong> ${fmt(totalIPs)}</span>
+          </div>
+        `;
 
         // Générer les filtres pour les masques cibles
         generateFilterCheckboxes(baseMask + 1, 30);
@@ -360,7 +391,7 @@
           const block = document.createElement("div");
           block.className = "mask-block";
           block.id = `block-mask-${targetMask}`;
-          block.innerHTML = `<div class="mask-header">Masque /${targetMask} <span class="mask-info">${count} sous-réseaux</span></div>`;
+          block.innerHTML = `<div class="mask-header">Masque /${targetMask} <span class="mask-info">${count} sous-réseau${count > 1 ? "x" : ""} &nbsp;·&nbsp; ${fmt(subnetSize)} IPs/sous-réseau</span></div>`;
 
           const grid = document.createElement("div");
           grid.className = "grid";


### PR DESCRIPTION
When decomposing a network, a summary banner now displays the first address, last address, and total IP count for the entered CIDR block. Each subnet mask section header also shows how many IPs each individual subnet contains.

### Changes
- New `.network-summary` banner shown after decomposition: normalized network, first address, last address, total IP count
- Each mask block header now reads e.g. `4 sous-réseaux · 256 IPs/sous-réseau`
- README: added subnet calculator to the tools table